### PR TITLE
feat: display category list from database

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,14 +31,25 @@ export default function App() {
       </button>
 
       {state === "success" && (
-        <p className="mt-3 text-success fw-bold">✅ Online</p>
+        <div className="mt-3">
+          <p className="text-success fw-bold">✅ Online</p>
+          <div className="mt-4">
+            <h2 className="h5">Supported Request Categories:</h2>
+            <ul className="list-unstyled">
+              {categories.map((category) => (
+                <li key={category.id}>• {category.name}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
       )}
 
       {state === "error" && (
-        <p className="mt-3 text-danger fw-bold">❌ Offline — Backend is unavailable</p>
+        <div className="mt-3 text-danger fw-bold">
+          <p>❌ Offline</p>
+          <p>Unable to connect to TokTickIT API</p>
+        </div>
       )}
-
-      {/* TODO(Issue 4): render category list here */}
     </div>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -19,6 +19,10 @@ export async function checkSystem(): Promise<SystemStatus> {
   const healthRes = await fetch(`${API_URL}/api/health`);
   if (!healthRes.ok) throw new Error("Backend is not responding");
 
-  // TODO(Issue 4): fetch categories here
-  return { online: true, categories: [] };
+  const categoriesRes = await fetch(`${API_URL}/api/categories`);
+  if (!categoriesRes.ok) throw new Error("Failed to fetch categories");
+  
+  const categories: Category[] = await categoriesRes.json();
+  
+  return { online: true, categories };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import App from "../../src/App.js";
+import * as api from "../../src/api.js";
 
 describe("App", () => {
   // WORKED EXAMPLE — provided for you.
@@ -12,6 +13,34 @@ describe("App", () => {
   // Issue 4 — write these yourself. Hint: mock the api module with
   // vi.spyOn(api, "checkSystem").mockResolvedValue(...) / .mockRejectedValue(...)
   // then click the button and assert the Online list / Offline message.
-  it.todo("shows Online and the seeded categories on success");
-  it.todo("shows an Offline error message when the API is unavailable");
+  it("shows Online and the seeded categories on success", async () => {
+    vi.spyOn(api, "checkSystem").mockResolvedValue({
+      online: true,
+      categories: [
+        { id: 1, name: "Account and Access" },
+        { id: 2, name: "Hardware" },
+      ],
+    });
+
+    render(<App />);
+    fireEvent.click(screen.getByText("Check System"));
+
+    await waitFor(() => {
+      expect(screen.getByText("✅ Online")).toBeInTheDocument();
+      expect(screen.getByText("• Account and Access")).toBeInTheDocument();
+      expect(screen.getByText("• Hardware")).toBeInTheDocument();
+    });
+  });
+
+  it("shows an Offline error message when the API is unavailable", async () => {
+    vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("Network Error"));
+
+    render(<App />);
+    fireEvent.click(screen.getByText("Check System"));
+
+    await waitFor(() => {
+      expect(screen.getByText("❌ Offline")).toBeInTheDocument();
+      expect(screen.getByText("Unable to connect to TokTickIT API")).toBeInTheDocument();
+    });
+  });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -30,5 +30,23 @@ app.get("/api/health", (_req: Request, res: Response) => {
 //   -> on failure, respond 500 with a safe message (no internal details)
 // TODO(Issue 4): implement the route here.
 // ---------------------------------------------------------------------------
+app.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const prisma = getPrisma();
+    const categories = await prisma.category.findMany({
+      select: {
+        id: true,
+        name: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+    res.status(200).json(categories);
+  } catch (error) {
+    console.error("Failed to fetch categories:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
 
 export default app;

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -7,9 +7,16 @@ void request; void app;
 // Requires the DB to be migrated and seeded first.
 // It should assert: GET /api/categories returns 200 and the four seeded
 // category names in id order.
-describe.todo("GET /api/categories", () => {
-  it.todo("returns the four seeded categories in id order", async () => {
+describe("GET /api/categories", () => {
+  it("returns the four seeded categories in id order", async () => {
     // TODO(Issue 4): implement this assertion.
-    expect(true).toBe(true);
+    const res = await request(app).get("/api/categories");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      { id: 1, name: "Account and Access" },
+      { id: 2, name: "Hardware" },
+      { id: 3, name: "Software" },
+      { id: 4, name: "Network" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
Implements the `GET /api/categories` endpoint and connects it end-to-end so the client fetches and displays the seeded category list after a successful health check.

## Changes

**Server (`server/src/app.ts`)**
- Add `GET /api/categories` route that queries `prisma.category.findMany()`, selecting `id` and `name`, ordered by `id` ascending
- Wrap the query in try/catch — returns `200` with the category list on success, `500` with a generic `{ error: "Internal Server Error" }` on failure (no internal error details leaked)

**Client (`client/src/api.ts`)**
- `checkSystem()` now calls `GET /api/categories` after the health check succeeds, throws if the request fails, and returns the categories alongside `online: true`

**Client (`client/src/App.tsx`)**
- On success, renders a "Supported Request Categories" list from the fetched categories
- On error, shows a clearer offline message: "❌ Offline" + "Unable to connect to TokTickIT API"

## Tests
- `server/tests/lab-01/categories.test.ts`: asserts `GET /api/categories` returns 200 and the four seeded categories (Account and Access, Hardware, Software, Network) in id order
- `client/tests/lab-01/App.test.tsx`:
  - mocks `checkSystem` to resolve with categories → asserts "✅ Online" and each category renders
  - mocks `checkSystem` to reject → asserts the offline error message renders

## Related Issue
Closes #4

## Testing
- [x] Verified category list renders correctly on page load
- [x] Verified data matches records in the database
- [x] Manually tested API endpoint (e.g. via Postman/Thunder Client)